### PR TITLE
Turned off source maps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Atomic building blocks to build custom payment interfaces",
     "typings": "types/index.d.ts",
     "keywords": [

--- a/tsconfig.react.json
+++ b/tsconfig.react.json
@@ -14,12 +14,12 @@
         // output .d.ts declaration files for consumers
         "declaration": true,
         // output .js.map sourcemap files for consumers
-        "sourceMap": true,
+        "sourceMap": false,
         // match output dir to input dir. e.g. dist/index instead of dist/src/index
         "rootDir": "./src",
         "jsx": "react",
         "target": "es5",
-        "declarationMap": true,
+        "declarationMap": false,
         "outDir": "./dist/react",
         // stricter type-checking for stronger correctness. Recommended by TS
         "strict": true,
@@ -37,8 +37,6 @@
         // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
         "skipLibCheck": true,
         // error out if import and file system have a casing mismatch. Recommended by TS
-        "forceConsistentCasingInFileNames": true,
-        // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-        //"noEmit": true,
+        "forceConsistentCasingInFileNames": true
     }
 }


### PR DESCRIPTION
# Description

Turned off source maps.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] UI change (Front-end UI update without breaking changes or business logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Description

1. **What is the current behavior?** (You can also link to an open issue here)

Source maps are generated when building.

2. **What is the new behavior (if this is a feature change)?**


3. **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Now it doesn't generate source maps.

# How Has This Been Tested?

By building locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
