### PR TITLE
Harden Atoms iframe bridge origins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "packageManager": "pnpm@10.11.1",
     "description": "Atomic building blocks to build custom payment interfaces",
     "type": "module",

--- a/src/atoms/CardCaptureIframe/iframe.tsx
+++ b/src/atoms/CardCaptureIframe/iframe.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { generateUUID } from '../../utils/funcs/generateUUID';
+import { resolveExactOrigin } from '../../utils/funcs/bridgeOrigin';
 import useFunctionQueue from '../hooks/useFunctionQueue';
 
 interface InframeProps {
@@ -57,6 +58,10 @@ const InframeComponent = React.forwardRef(
     const flushPendingMessagesRef = React.useRef<() => void>(() => {});
     const messagesProcessedCallback = React.useRef<(() => void) | null>(null);
     const functionQueue = useFunctionQueue();
+    const iframeOrigin = React.useMemo(
+      () => resolveExactOrigin(src, typeof window === 'undefined' ? undefined : window.location.href),
+      [src]
+    );
 
     const dispatchMessage = React.useCallback((entry: PendingMessage) => {
       const target = iframeRef.current?.contentWindow;
@@ -65,7 +70,12 @@ const InframeComponent = React.forwardRef(
         return;
       }
 
-      target.postMessage(entry.payload, '*');
+      if (!iframeOrigin) {
+        console.warn(`Unable to post message to iframe with invalid origin: ${src}`);
+        return;
+      }
+
+      target.postMessage(entry.payload, iframeOrigin);
 
       if (entry.expectAck && entry.payload.messageId) {
         const timeoutId = window.setTimeout(() => {
@@ -77,7 +87,7 @@ const InframeComponent = React.forwardRef(
         }, ACK_TIMEOUT_MS);
         inflightAcksRef.current.set(entry.payload.messageId, { entry, timeoutId });
       }
-    }, []);
+    }, [iframeOrigin, src]);
 
     const flushPendingMessages = React.useCallback(() => {
       if (!isReadyRef.current || !iframeRef.current?.contentWindow) return;
@@ -104,12 +114,17 @@ const InframeComponent = React.forwardRef(
     React.useEffect(() => {
       // Message event handler for iframe communications
       const messageHandler = (event: MessageEvent) => {
+        const data = event.data;
         if (
+          iframeOrigin &&
           iframeRef.current &&
           event.source === iframeRef.current.contentWindow &&
-          event.data.type === 'safepay-inframe-event'
+          event.origin === iframeOrigin &&
+          data &&
+          typeof data === 'object' &&
+          data.type === 'safepay-inframe-event'
         ) {
-          const { name, detail } = event.data;
+          const { name, detail } = data;
           if (name === 'safepay-inframe__ack') {
             const { messageId, status, detail: ackDetail } = detail || {};
             if (messageId && inflightAcksRef.current.has(messageId)) {
@@ -138,7 +153,7 @@ const InframeComponent = React.forwardRef(
 
       window.addEventListener('message', messageHandler);
       return () => window.removeEventListener('message', messageHandler);
-    }, [flushPendingMessages, onInframeEvent]);
+    }, [flushPendingMessages, iframeOrigin, onInframeEvent]);
 
     React.useEffect(() => {
       // Reset readiness whenever the iframe source changes

--- a/src/atoms/CardCaptureIframe/index.tsx
+++ b/src/atoms/CardCaptureIframe/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppendStyles } from '../../styles';
+import { appendParentOriginToIframeSrc } from '../../utils/funcs/bridgeOrigin';
 import { resolveBaseUrl } from '../../utils/funcs/resolveBaseUrl';
 import InframeComponent from './iframe';
 import { Environment, toEnvironment } from '../../types/environment';
@@ -77,6 +78,14 @@ const CardCapture = ({
   // Base URL resolution based on the environment
   const normalizedEnv = toEnvironment(environment);
   const baseURL = resolveBaseUrl(normalizedEnv);
+  const iframeSrc = useMemo(
+    () =>
+      appendParentOriginToIframeSrc(
+        `${baseURL}/cardlink`,
+        typeof window === 'undefined' ? undefined : window.location.href
+      ),
+    [baseURL]
+  );
 
   useEffect(() => {
     // Styles computation and application logic
@@ -170,7 +179,7 @@ const CardCapture = ({
     <div className="safepay-atoms-root" ref={styleRef}>
       <div className={`iframeWrapper ${isFocused ? 'focus' : ''}`}>
         <InframeComponent
-          src={`${baseURL}/cardlink`}
+          src={iframeSrc}
           title="Safepay Credit/Debit Card Input"
           ref={inframeMethodsRef}
           onInframeEvent={handleInframeEvent}

--- a/src/atoms/PayerAuthenticationIframe/iframe.tsx
+++ b/src/atoms/PayerAuthenticationIframe/iframe.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { generateUUID } from '../../utils/funcs/generateUUID';
+import { resolveExactOrigin } from '../../utils/funcs/bridgeOrigin';
 import useFunctionQueue from '../hooks/useFunctionQueue';
 
 interface InframeProps {
@@ -57,6 +58,10 @@ const InframeComponent = React.forwardRef(
     const flushPendingMessagesRef = React.useRef<() => void>(() => {});
     const messagesProcessedCallback = React.useRef<(() => void) | null>(null);
     const functionQueue = useFunctionQueue();
+    const iframeOrigin = React.useMemo(
+      () => resolveExactOrigin(src, typeof window === 'undefined' ? undefined : window.location.href),
+      [src]
+    );
 
     const dispatchMessage = React.useCallback((entry: PendingMessage) => {
       const target = iframeRef.current?.contentWindow;
@@ -65,7 +70,12 @@ const InframeComponent = React.forwardRef(
         return;
       }
 
-      target.postMessage(entry.payload, '*');
+      if (!iframeOrigin) {
+        console.warn(`Unable to post message to iframe with invalid origin: ${src}`);
+        return;
+      }
+
+      target.postMessage(entry.payload, iframeOrigin);
 
       if (entry.expectAck && entry.payload.messageId) {
         const timeoutId = window.setTimeout(() => {
@@ -77,7 +87,7 @@ const InframeComponent = React.forwardRef(
         }, ACK_TIMEOUT_MS);
         inflightAcksRef.current.set(entry.payload.messageId, { entry, timeoutId });
       }
-    }, []);
+    }, [iframeOrigin, src]);
 
     const flushPendingMessages = React.useCallback(() => {
       if (!isReadyRef.current || !iframeRef.current?.contentWindow) return;
@@ -104,12 +114,17 @@ const InframeComponent = React.forwardRef(
     React.useEffect(() => {
       // Message event handler for iframe communications
       const messageHandler = (event: MessageEvent) => {
+        const data = event.data;
         if (
+          iframeOrigin &&
           iframeRef.current &&
           event.source === iframeRef.current.contentWindow &&
-          event.data.type === 'safepay-inframe-event'
+          event.origin === iframeOrigin &&
+          data &&
+          typeof data === 'object' &&
+          data.type === 'safepay-inframe-event'
         ) {
-          const { name, detail } = event.data;
+          const { name, detail } = data;
           if (name === 'safepay-inframe__ack') {
             const { messageId, status, detail: ackDetail } = detail || {};
             if (messageId && inflightAcksRef.current.has(messageId)) {
@@ -138,7 +153,7 @@ const InframeComponent = React.forwardRef(
 
       window.addEventListener('message', messageHandler);
       return () => window.removeEventListener('message', messageHandler);
-    }, [flushPendingMessages, onInframeEvent]);
+    }, [flushPendingMessages, iframeOrigin, onInframeEvent]);
 
     React.useEffect(() => {
       // Reset readiness whenever the iframe source changes

--- a/src/atoms/PayerAuthenticationIframe/index.tsx
+++ b/src/atoms/PayerAuthenticationIframe/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppendStyles } from '../../styles';
+import { appendParentOriginToIframeSrc } from '../../utils/funcs/bridgeOrigin';
 import { resolveBaseUrl } from '../../utils/funcs/resolveBaseUrl';
 import InframeComponent from './iframe';
 import { PayerAuthenticationProps } from './types';
@@ -40,6 +41,14 @@ const PayerAuthentication = ({
   // Base URL resolution based on the environment
   const normalizedEnv = toEnvironment(environment);
   const baseURL = resolveBaseUrl(normalizedEnv);
+  const iframeSrc = useMemo(
+    () =>
+      appendParentOriginToIframeSrc(
+        `${baseURL}/authlink`,
+        typeof window === 'undefined' ? undefined : window.location.href
+      ),
+    [baseURL]
+  );
 
   // Computed props for iframe integration
   const computedProps = useMemo(
@@ -110,7 +119,7 @@ const PayerAuthentication = ({
     <div className="safepay-atoms-root" ref={styleRef}>
       <div className="payerAuthiframeWrapper">
         <InframeComponent
-          src={`${baseURL}/authlink`}
+          src={iframeSrc}
           title="Safepay Payer Authentication"
           ref={inframeMethodsRef}
           onInframeEvent={handleInframeEvent}

--- a/src/utils/funcs/bridgeOrigin.ts
+++ b/src/utils/funcs/bridgeOrigin.ts
@@ -1,0 +1,27 @@
+const BRIDGE_PARENT_ORIGIN_QUERY_PARAM = 'parentOrigin';
+
+export const resolveExactOrigin = (value?: string | null, base?: string): string | null => {
+  if (!value) return null;
+
+  try {
+    const origin = base ? new URL(value, base).origin : new URL(value).origin;
+    return origin === 'null' ? null : origin;
+  } catch {
+    return null;
+  }
+};
+
+export const appendParentOriginToIframeSrc = (src: string, parentHref?: string): string => {
+  try {
+    const url = parentHref ? new URL(src, parentHref) : new URL(src);
+    const parentOrigin = resolveExactOrigin(parentHref);
+
+    if (parentOrigin) {
+      url.searchParams.set(BRIDGE_PARENT_ORIGIN_QUERY_PARAM, parentOrigin);
+    }
+
+    return url.toString();
+  } catch {
+    return src;
+  }
+};

--- a/tests/e2e/atoms.spec.ts
+++ b/tests/e2e/atoms.spec.ts
@@ -84,8 +84,23 @@ const createMockDropsPage = (label: string, options?: { autoAck?: boolean }) => 
     <div id="stub-${label}">Mocked ${label}</div>
     <script>
       (function () {
+        const resolveExactOrigin = (value) => {
+          if (!value) return null;
+          try {
+            const origin = new URL(value, window.location.href).origin;
+            return origin === 'null' ? null : origin;
+          } catch {
+            return null;
+          }
+        };
+
+        const parentOrigin =
+          resolveExactOrigin(new URL(window.location.href).searchParams.get('parentOrigin')) ||
+          resolveExactOrigin(document.referrer);
+
         const sendEvent = (name, detail) => {
-          window.parent.postMessage({ type: 'safepay-inframe-event', name, detail }, '*');
+          if (!parentOrigin) return;
+          window.parent.postMessage({ type: 'safepay-inframe-event', name, detail }, parentOrigin);
         };
 
         window.__messageLog = {
@@ -93,6 +108,7 @@ const createMockDropsPage = (label: string, options?: { autoAck?: boolean }) => 
           counts: {},
           lastProps: null,
           lastPropMessageId: null,
+          parentOrigin,
           autoAck: ${options?.autoAck ?? true},
         };
 
@@ -100,6 +116,7 @@ const createMockDropsPage = (label: string, options?: { autoAck?: boolean }) => 
 
         window.addEventListener('message', (event) => {
           const data = event.data || {};
+          if (!parentOrigin || event.origin !== parentOrigin) return;
           if (!data.type) return;
 
           const id = data.messageId || 'no-id';
@@ -160,8 +177,8 @@ test.describe('Safepay Atoms messaging to drops', () => {
       });
     };
 
-    await page.route('**/drops/cardlink', fulfillMock);
-    await page.route('**/drops/authlink', fulfillMock);
+    await page.route('**/cardlink*', fulfillMock);
+    await page.route('**/authlink*', fulfillMock);
 
     await renderHost(page);
 
@@ -189,12 +206,22 @@ test.describe('Safepay Atoms messaging to drops', () => {
 
     const cardProps = await cardFrame.evaluate(() => {
       const log = (window as any).__messageLog;
-      return { lastProps: log.lastProps, lastPropMessageId: log.lastPropMessageId, counts: log.counts };
+      return {
+        lastProps: log.lastProps,
+        lastPropMessageId: log.lastPropMessageId,
+        counts: log.counts,
+        parentOrigin: log.parentOrigin,
+      };
     });
 
     const authProps = await authFrame.evaluate(() => {
       const log = (window as any).__messageLog;
-      return { lastProps: log.lastProps, lastPropMessageId: log.lastPropMessageId, counts: log.counts };
+      return {
+        lastProps: log.lastProps,
+        lastPropMessageId: log.lastPropMessageId,
+        counts: log.counts,
+        parentOrigin: log.parentOrigin,
+      };
     });
 
     expect(cardProps.lastProps).toMatchObject({
@@ -210,6 +237,8 @@ test.describe('Safepay Atoms messaging to drops', () => {
       authToken,
       user,
     });
+    expect(cardProps.parentOrigin).toBe('http://localhost:4173');
+    expect(authProps.parentOrigin).toBe('http://localhost:4173');
 
     await page.waitForTimeout(1200);
 
@@ -244,8 +273,8 @@ test.describe('Safepay Atoms messaging to drops', () => {
       });
     };
 
-    await page.route('**/drops/cardlink', fulfillMock);
-    await page.route('**/drops/authlink', fulfillMock);
+    await page.route('**/cardlink*', fulfillMock);
+    await page.route('**/authlink*', fulfillMock);
 
     await renderHost(page);
 
@@ -289,14 +318,14 @@ test.describe('Safepay Atoms messaging to drops', () => {
   test('handles drops events and toggles modal on proceed/success', async ({ page }) => {
     test.skip(useRealDrops, 'Runs only with mocked drops');
 
-    await page.route('**/drops/cardlink', async (route) =>
+    await page.route('**/cardlink*', async (route) =>
       route.fulfill({
         status: 200,
         contentType: 'text/html',
         body: createMockDropsPage('cardlink'),
       })
     );
-    await page.route('**/drops/authlink', async (route) =>
+    await page.route('**/authlink*', async (route) =>
       route.fulfill({
         status: 200,
         contentType: 'text/html',
@@ -316,6 +345,10 @@ test.describe('Safepay Atoms messaging to drops', () => {
     await authFrame.waitForFunction(() => Boolean((window as any).__messageLog?.lastPropMessageId));
 
     await cardFrame.evaluate(() => {
+      const parentOrigin = new URL(
+        new URL(window.location.href).searchParams.get('parentOrigin') || document.referrer
+      ).origin;
+
       window.parent.postMessage(
         {
           type: 'safepay-inframe-event',
@@ -325,7 +358,7 @@ test.describe('Safepay Atoms messaging to drops', () => {
             deviceDataCollectionURL: 'https://example.test/ddc',
           },
         },
-        '*'
+        parentOrigin
       );
     });
 
@@ -349,17 +382,95 @@ test.describe('Safepay Atoms messaging to drops', () => {
     if (!authFrameLatest) throw new Error('authlink frame not found after proceed event');
 
     await authFrameLatest.evaluate(() => {
+      const parentOrigin = new URL(
+        new URL(window.location.href).searchParams.get('parentOrigin') || document.referrer
+      ).origin;
+
       window.parent.postMessage(
         {
           type: 'safepay-inframe-event',
           name: 'safepay-inframe__cardinal-3ds__success',
           detail: { status: 'ok' },
         },
-        '*'
+        parentOrigin
       );
     });
 
     await expect(page.locator('#threeds-modal')).toHaveClass(/hide/);
+  });
+
+  test('rejects inframe events from unexpected origins', async ({ page }) => {
+    test.skip(useRealDrops, 'Runs only with mocked drops');
+
+    await page.route('**/cardlink*', async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: createMockDropsPage('cardlink'),
+      })
+    );
+    await page.route('**/authlink*', async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: createMockDropsPage('authlink'),
+      })
+    );
+
+    await renderHost(page);
+
+    await page.waitForSelector('iframe[src*="/drops/cardlink"]', { state: 'attached' });
+    await page.waitForSelector('iframe[src*="/drops/authlink"]', { state: 'attached' });
+
+    const cardFrame = await waitForFrameUrl(page, '/drops/cardlink');
+    const authFrame = await waitForFrameUrl(page, '/drops/authlink');
+
+    await cardFrame.waitForFunction(() => Boolean((window as any).__messageLog?.lastPropMessageId));
+    await authFrame.waitForFunction(() => Boolean((window as any).__messageLog?.lastPropMessageId));
+
+    await page.evaluate(() => {
+      const attacker = document.createElement('iframe');
+      attacker.srcdoc = `
+        <!doctype html>
+        <html>
+          <body>
+            <script>
+              window.parent.__maliciousFrameSent = true;
+              window.parent.postMessage(
+                {
+                  type: 'safepay-inframe-event',
+                  name: 'safepay-inframe__proceed__authentication',
+                  detail: {
+                    accessToken: 'evil_token',
+                    deviceDataCollectionURL: 'https://evil.test/ddc',
+                  },
+                },
+                window.parent.location.origin
+              );
+            <\/script>
+          </body>
+        </html>
+      `;
+      document.body.appendChild(attacker);
+    });
+
+    await page.waitForFunction(() => (window as any).__maliciousFrameSent === true);
+    await page.waitForTimeout(250);
+
+    await expect(page.locator('#threeds-modal')).toHaveClass(/hide/);
+
+    const payerAuthData = await page.evaluate(() => {
+      const payerAuthAtom = document.querySelector('safepay-payer-auth-atom') as any;
+      return {
+        deviceDataCollectionJWT: payerAuthAtom.deviceDataCollectionJWT ?? null,
+        deviceDataCollectionURL: payerAuthAtom.deviceDataCollectionURL ?? null,
+      };
+    });
+
+    expect(payerAuthData).toEqual({
+      deviceDataCollectionJWT: null,
+      deviceDataCollectionURL: null,
+    });
   });
 
   test('opt-in: happy path typing against live drops', async ({ page }) => {


### PR DESCRIPTION
## Summary
- derive the Drops target origin from the iframe `src` using exact `new URL(...).origin`
- append the embedding page origin to the iframe URL as `parentOrigin` so Drops can safely reply to the correct parent
- reject inbound iframe events unless both `event.source` and `event.origin` match the expected Drops iframe
- keep ack/retry and lifecycle behavior intact, with E2E coverage for valid and invalid origin flows

## Verification
- `pnpm exec playwright test tests/e2e/atoms.spec.ts`
- `pnpm build`

## Companion PR
- Drops PR: https://github.com/getsafepay/safepay-drops/pull/52
