### PR TITLE
Align payer auth billing shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,6 +718,7 @@ const inputStyle = {
 ### Billing
 
 Used by `PayerAuthentication` and `<safepay-payer-authentication>`.
+`street_2`, `state`, and `postal_code` are optional.
 
 ```ts
 type Billing = {

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The `<safepay-payer-authentication>` component handles payer authentication flow
     street_1: '123 Main Street',
     street_2: 'Suite 500',
     city: 'Berlin',
+    state: 'BE',
     country: 'DE',
     postal_code: '10115',
   };
@@ -316,6 +317,7 @@ Attributes are string-only. For callbacks and objects, set properties directly:
     street_1: '123 Main Street',
     street_2: 'Suite 500',
     city: 'Berlin',
+    state: 'BE',
     country: 'DE',
     postal_code: '10115',
   };
@@ -457,6 +459,7 @@ const billing = {
   street_1: '123 Main Street',
   street_2: 'Suite 500',
   city: 'Berlin',
+  state: 'BE',
   country: 'DE',
   postal_code: '10115',
 };
@@ -579,6 +582,7 @@ const BILLING = {
   street_1: '123 Main Street',
   street_2: 'Suite 500',
   city: 'Berlin',
+  state: 'BE',
   country: 'DE',
   postal_code: '10115',
 };
@@ -720,6 +724,7 @@ type Billing = {
   street_1: string;
   street_2?: string;
   city: string;
+  state?: string;
   country: string;
   postal_code?: string;
 };
@@ -732,6 +737,7 @@ const billing = {
   street_1: '123 Main Street',
   street_2: 'Suite 500',
   city: 'Berlin',
+  state: 'BE',
   country: 'DE',
   postal_code: '10115',
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "packageManager": "pnpm@10.11.1",
     "description": "Atomic building blocks to build custom payment interfaces",
     "type": "module",

--- a/src/atoms/PayerAuthenticationIframe/types.ts
+++ b/src/atoms/PayerAuthenticationIframe/types.ts
@@ -16,6 +16,7 @@ interface Billing {
   street_1: string;
   street_2?: string;
   city: string;
+  state?: string;
   country: string;
   postal_code?: string;
 }


### PR DESCRIPTION
## Summary
- add optional state to the Atoms payer-auth billing type
- update the README billing shape and examples to match the supported contract
- keep the change non-breaking by leaving street_2 optional

## Verification
- pnpm build

## Companion PR
- safepay-drops: https://github.com/getsafepay/safepay-drops/pull/57