### PR TITLE
fix: skip style chunk lookup when window.atoms is uninitialised

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "packageManager": "pnpm@10.11.1",
     "description": "Atomic building blocks to build custom payment interfaces",
     "type": "module",

--- a/src/styles/hooks/useStyles.ts
+++ b/src/styles/hooks/useStyles.ts
@@ -53,6 +53,8 @@ export const useAppendStyles = (chunkName: ChunkName, isShadow: boolean) => {
    * @returns {ChunkName[]} An array of related chunk names.
    */
   const getRelatedStyleChunks = (name: ChunkName): ChunkName[] => {
+    if (!window.atoms?.styleChunks) return [];
+
     const chunks = [...(window.atoms?.jsChunkImports?.[name] || []), name].filter(
       (chunk) => !!window.atoms?.styleChunks?.[chunk]
     );


### PR DESCRIPTION
## Summary
- Guards `getRelatedStyleChunks` in `useStyles.ts` against `window.atoms.styleChunks` being absent
- When `CardCapture` is used as a React component (not via the web component bootstrap), `window.atoms` is never populated and the hook was logging an error on every mount
- Early return with `[]` when `styleChunks` is missing — styles are already bundled in `react/index.css` on this path so no lookup is needed
- Bumps version to 0.3.3

## Test plan
- [ ] Import `CardCapture` directly as a React component and confirm no style chunk error in console on mount
- [ ] Verify web component path (`safepay-card-atom`) still applies styles correctly