### PR TITLE
feat: live E2E regression suite against real backend

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -30,3 +30,33 @@ jobs:
 
       - name: Run Playwright tests (atoms project)
         run: pnpm exec playwright test --project=atoms
+
+  e2e-live:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps
+
+      - name: Run live regression tests
+        run: pnpm exec playwright test --project=atoms
+        env:
+          USE_REAL_DROPS: ${{ vars.USE_REAL_DROPS }}
+          DROPS_ENV: ${{ vars.DROPS_ENV }}
+          X_SFPY_MERCHANT_SECRET: ${{ secrets.X_SFPY_MERCHANT_SECRET }}
+          SFPY_MERCHANT_API_KEY: ${{ secrets.SFPY_MERCHANT_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "react": "dist/react/index.js",
     "devDependencies": {
         "@playwright/test": "^1.57.0",
+        "@sfpy/node-core": "^0.3.5",
+        "axios": "^1.15.0",
+        "@types/node": "^20.0.0",
         "@swc/core": "^1.15.8",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "packageManager": "pnpm@10.11.1",
     "description": "Atomic building blocks to build custom payment interfaces",
     "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,15 @@ importers:
       '@playwright/test':
         specifier: ^1.57.0
         version: 1.57.0
+      '@sfpy/node-core':
+        specifier: ^0.3.5
+        version: 0.3.5
       '@swc/core':
         specifier: ^1.15.8
         version: 1.15.8
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.41
       '@types/react':
         specifier: ^18.2.48
         version: 18.3.27
@@ -39,6 +45,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.22(postcss@8.5.6)
+      axios:
+        specifier: ^1.15.0
+        version: 1.16.1
       cssnano:
         specifier: ^7.0.6
         version: 7.1.2(postcss@8.5.6)
@@ -509,6 +518,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sfpy/node-core@0.3.5':
+    resolution: {integrity: sha512-idA/srpwhbENyyEO+5J4rIVYqqv7E2SKb2fpv37YDf9mr6sAHMoYLzmeQdNjRqs4Sd8xz+wBflnScIQD4d7XIA==}
+
   '@swc/core-darwin-arm64@1.15.8':
     resolution: {integrity: sha512-M9cK5GwyWWRkRGwwCbREuj6r8jKdES/haCZ3Xckgkl8MUQJZA3XB7IXXK1IXRNeLjg6m7cnoMICpXv1v1hlJOg==}
     engines: {node: '>=10'}
@@ -589,6 +601,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.19.41':
+    resolution: {integrity: sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==}
 
   '@types/postcss-modules-local-by-default@4.0.2':
     resolution: {integrity: sha512-CtYCcD+L+trB3reJPny+bKWKMzPfxEyQpKIwit7kErnOexf5/faaGpkFy4I5AwbV4hp1sk7/aTg0tt0B67VkLQ==}
@@ -679,6 +694,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -736,6 +755,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   autoprefixer@10.4.22:
     resolution: {integrity: sha512-ARe0v/t9gO28Bznv6GgqARmVqcWOV3mfgUPn9becPHMiD3o9BwlRgaeccZnwTpZ7Zwqrm+c1sUSsMxIzQzc8Xg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -746,6 +768,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -875,6 +900,10 @@ packages:
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1011,6 +1040,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   dependency-graph@1.0.0:
     resolution: {integrity: sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==}
@@ -1192,9 +1225,22 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -1317,6 +1363,10 @@ packages:
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2139,12 +2189,20 @@ packages:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
@@ -2540,6 +2598,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2926,6 +2987,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.53.3':
     optional: true
 
+  '@sfpy/node-core@0.3.5':
+    dependencies:
+      qs: 6.15.2
+
   '@swc/core-darwin-arm64@1.15.8':
     optional: true
 
@@ -2981,6 +3046,10 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.19.41':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/postcss-modules-local-by-default@4.0.2':
     dependencies:
@@ -3101,6 +3170,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3163,6 +3238,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   autoprefixer@10.4.22(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.0
@@ -3176,6 +3253,16 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -3318,6 +3405,10 @@ snapshots:
   color-name@1.1.4: {}
 
   colord@2.9.3: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@11.1.0: {}
 
@@ -3482,6 +3573,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   dependency-graph@1.0.0: {}
 
@@ -3760,9 +3853,19 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.18
 
   fraction.js@5.3.4: {}
 
@@ -3886,6 +3989,13 @@ snapshots:
       function-bind: 1.1.2
 
   hosted-git-info@2.8.9: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@2.1.0: {}
 
@@ -4625,10 +4735,16 @@ snapshots:
 
   pretty-hrtime@1.0.3: {}
 
+  proxy-from-env@2.1.0: {}
+
   prr@1.0.1:
     optional: true
 
   punycode@2.3.1: {}
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
 
   range-parser@1.2.0: {}
 
@@ -5147,6 +5263,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
 
   universalify@2.0.1: {}
 

--- a/src/styles/hooks/useStyles.ts
+++ b/src/styles/hooks/useStyles.ts
@@ -53,6 +53,8 @@ export const useAppendStyles = (chunkName: ChunkName, isShadow: boolean) => {
    * @returns {ChunkName[]} An array of related chunk names.
    */
   const getRelatedStyleChunks = (name: ChunkName): ChunkName[] => {
+    if (!window.atoms?.styleChunks) return [];
+
     const chunks = [...(window.atoms?.jsChunkImports?.[name] || []), name].filter(
       (chunk) => !!window.atoms?.styleChunks?.[chunk]
     );

--- a/tests/e2e/atoms.spec.ts
+++ b/tests/e2e/atoms.spec.ts
@@ -1,14 +1,9 @@
 import { expect, test, Page, Frame } from '@playwright/test';
+import { createLiveSession, createTracker, LiveSession } from './live-session';
+import { REGRESSION_CARDS } from './test-cards';
 
 const useRealDrops = process.env.USE_REAL_DROPS === '1';
 const dropsEnv = (process.env.DROPS_ENV || 'sandbox').toLowerCase();
-const dropsBaseByEnv: Record<string, string> = {
-  sandbox: 'https://sandbox.api.getsafepay.com/drops',
-  development: 'https://dev.api.getsafepay.com/drops',
-  production: 'https://getsafepay.com/drops',
-  local: 'http://127.0.0.1:3000',
-};
-const dropsBase = process.env.DROPS_BASE || dropsBaseByEnv[dropsEnv] || dropsBaseByEnv.sandbox;
 
 const waitForFrameUrl = async (page: Page, substring: string): Promise<Frame> => {
   const existing = page.frames().find((frame) => frame.url().includes(substring) && frame.url() !== 'about:blank');
@@ -56,13 +51,27 @@ const renderHost = async (page: Page) => {
             payerAuthAtom.deviceDataCollectionURL = data.deviceDataCollectionURL;
             modal.classList.remove('hide');
             modal.classList.add('show');
+            window.__atomsCallbacks.proceedToAuthentication = data;
           };
 
-          payerAuthAtom.onPayerAuthenticationSuccess = function () {
+          payerAuthAtom.onPayerAuthenticationSuccess = function (data) {
             modal.classList.remove('show');
             modal.classList.add('hide');
+            window.__atomsCallbacks.success = data;
+          };
+          payerAuthAtom.onPayerAuthenticationFailure = function (data) {
+            modal.classList.remove('show');
+            modal.classList.add('hide');
+            window.__atomsCallbacks.failure = data;
+          };
+          payerAuthAtom.onPayerAuthenticationFrictionless = function (data) {
+            window.__atomsCallbacks.frictionless = data;
+          };
+          payerAuthAtom.onPayerAuthenticationUnavailable = function (data) {
+            window.__atomsCallbacks.unavailable = data;
           };
 
+          window.__atomsCallbacks = { proceedToAuthentication: null, success: null, failure: null, frictionless: null, unavailable: null };
           window.__atomsHost = { cardAtom, payerAuthAtom, modal };
           window.__atomsHostReady = true;
         };
@@ -473,96 +482,92 @@ test.describe('Safepay Atoms messaging to drops', () => {
     });
   });
 
-  test('opt-in: happy path typing against live drops', async ({ page }) => {
-    test.skip(!useRealDrops, 'Opt-in: set USE_REAL_DROPS=1 with a reachable drops instance');
+});
 
-    await renderHost(page);
+test.describe(`live regression against ${dropsEnv} drops`, () => {
+  test.skip(!useRealDrops, 'Opt-in: set USE_REAL_DROPS=1 and X_SFPY_MERCHANT_SECRET to run against a live backend');
 
-    const tracker = process.env.DROPS_TRACKER || 'tracker_live';
-    const authToken = process.env.DROPS_AUTH_TOKEN || 'secret_live';
-    const user = process.env.DROPS_USER || '';
-    const env = dropsEnv;
+  let session: LiveSession;
 
-    await page.evaluate(
-      ({ tracker, authToken, user, env }) => {
-        const { cardAtom, payerAuthAtom } = (window as any).__atomsHost;
-
-        cardAtom.environment = env;
-        cardAtom.authToken = authToken;
-        cardAtom.tracker = tracker;
-
-        payerAuthAtom.environment = env;
-        payerAuthAtom.authToken = authToken;
-        payerAuthAtom.tracker = tracker;
-        payerAuthAtom.user = user;
-      },
-      { tracker, authToken, user, env }
-    );
-
-    const cardFrame = await waitForFrameUrl(page, 'cardlink');
-    await cardFrame.waitForLoadState('domcontentloaded');
-
-    await cardFrame.getByPlaceholder(/Card number/i).fill('4242424242424242');
-    await cardFrame.getByPlaceholder(/^MM$/i).fill('12');
-    await cardFrame.getByPlaceholder(/^YY$/i).fill('34');
-    await cardFrame.getByPlaceholder(/CVV/i).fill('123');
-
-    await cardFrame.waitForTimeout(500);
+  test.beforeAll(async () => {
+    session = await createLiveSession();
   });
 
-  test('opt-in: records live drops requests', async ({ page }) => {
-    test.skip(!useRealDrops, 'Opt-in: set USE_REAL_DROPS=1 to run against live drops');
+  for (const card of REGRESSION_CARDS) {
+    test(`${card.scenario}: ${card.description}`, async ({ page }) => {
+      if (card.flow === 'step-up') test.setTimeout(90_000);
 
-    const tracker = process.env.DROPS_TRACKER || 'tracker_live';
-    const authToken = process.env.DROPS_AUTH_TOKEN || 'secret_live';
-    const user = process.env.DROPS_USER || '';
+      const tracker = await createTracker(session);
 
-    const requests: { url: string; method: string }[] = [];
-    page.context().on('request', (req) => {
-      const url = req.url();
-      if (url.includes('/cardlink') || url.includes('/authlink')) {
-        requests.push({ url, method: req.method() });
+      await renderHost(page);
+
+      await page.evaluate(
+        ({ authToken, tracker, user, env }) => {
+          const { cardAtom, payerAuthAtom } = (window as any).__atomsHost;
+
+          cardAtom.environment = env;
+          cardAtom.authToken = authToken;
+          cardAtom.tracker = tracker;
+
+          payerAuthAtom.environment = env;
+          payerAuthAtom.authToken = authToken;
+          payerAuthAtom.tracker = tracker;
+          payerAuthAtom.user = user;
+        },
+        { authToken: session.authToken, tracker, user: session.user, env: session.env }
+      );
+
+      const cardFrame = await waitForFrameUrl(page, 'cardlink');
+      await cardFrame.waitForLoadState('domcontentloaded');
+
+      await cardFrame.getByPlaceholder(/Card number/i).fill(card.number);
+      await cardFrame.getByPlaceholder(/^MM$/i).fill(card.expiry.mm);
+      await cardFrame.getByPlaceholder(/^YY$/i).fill(card.expiry.yy);
+      await cardFrame.getByPlaceholder(/CVV/i).fill(card.cvv);
+
+      await page.evaluate(() => (window as any).__atomsHost.cardAtom.submit());
+
+      if (card.flow === 'frictionless') {
+        if (card.outcome === 'proceed') {
+          await page.waitForFunction(
+            () => Boolean((window as any).__atomsCallbacks.frictionless),
+            { timeout: 20_000 }
+          );
+        } else {
+          // drops fires enrollment__failed → atoms routes to onPayerAuthenticationUnavailable
+          await page.waitForFunction(
+            () => Boolean((window as any).__atomsCallbacks.unavailable),
+            { timeout: 20_000 }
+          );
+        }
+      } else {
+        await page.waitForFunction(
+          () => Boolean((window as any).__atomsCallbacks.proceedToAuthentication),
+          { timeout: 20_000 }
+        );
+        await expect(page.locator('#threeds-modal')).toHaveClass(/show/);
+
+        // The authlink iframe navigates to Cardinal's step-up page, which renders
+        // a nested ACS iframe containing the challenge form.
+        const challengeFrame = page
+          .frameLocator('iframe').nth(1)  // payer auth iframe (now at Cardinal's URL)
+          .frameLocator('iframe');         // ACS challenge iframe inside Cardinal
+
+        await challengeFrame.getByPlaceholder('Enter Code Here').fill('1234');
+        await challengeFrame.getByRole('button', { name: 'SUBMIT' }).click();
+
+        if (card.outcome === 'proceed') {
+          await page.waitForFunction(
+            () => Boolean((window as any).__atomsCallbacks.success),
+            { timeout: 30_000 }
+          );
+        } else {
+          await page.waitForFunction(
+            () => Boolean((window as any).__atomsCallbacks.failure),
+            { timeout: 30_000 }
+          );
+        }
       }
     });
-
-    await renderHost(page);
-
-    const atomsAvailable = await page.evaluate(() => Boolean((window as any).atoms));
-    if (!atomsAvailable) {
-      throw new Error('window.atoms is not available; components script may not have loaded');
-    }
-
-    await page.evaluate(
-      ({ tracker, authToken, user, env }) => {
-        const { cardAtom, payerAuthAtom } = (window as any).__atomsHost;
-
-        cardAtom.setAttribute('environment', env);
-        cardAtom.setAttribute('auth-token', authToken);
-        cardAtom.setAttribute('tracker', tracker);
-        cardAtom.environment = env;
-        cardAtom.authToken = authToken;
-        cardAtom.tracker = tracker;
-
-        payerAuthAtom.setAttribute('environment', env);
-        payerAuthAtom.setAttribute('auth-token', authToken);
-        payerAuthAtom.setAttribute('tracker', tracker);
-        payerAuthAtom.setAttribute('user', user);
-        payerAuthAtom.environment = env;
-        payerAuthAtom.authToken = authToken;
-        payerAuthAtom.tracker = tracker;
-        payerAuthAtom.user = user;
-      },
-      { tracker, authToken, user, env: dropsEnv }
-    );
-
-    await expect.poll(() => requests.filter((r) => r.url.includes('cardlink')).length, {
-      timeout: 10000,
-    }).toBeGreaterThan(0);
-    await expect.poll(() => requests.filter((r) => r.url.includes('authlink')).length, {
-      timeout: 10000,
-    }).toBeGreaterThan(0);
-
-    const frameUrls = page.frames().map((f) => f.url());
-    test.info().annotations.push({ type: 'frames', description: frameUrls.join(', ') });
-  });
+  }
 });

--- a/tests/e2e/live-session.ts
+++ b/tests/e2e/live-session.ts
@@ -1,0 +1,57 @@
+import Safepay from '@sfpy/node-core';
+
+const API_HOST_BY_ENV: Record<string, string> = {
+  sandbox: 'https://sandbox.api.getsafepay.com',
+  development: 'https://dev.api.getsafepay.com',
+  production: 'https://api.getsafepay.com',
+};
+
+export interface LiveSession {
+  authToken: string;
+  user: string;
+  env: string;
+  _merchantApiKey: string;
+  _host: string;
+}
+
+export async function createLiveSession(): Promise<LiveSession> {
+  const secretKey = process.env.X_SFPY_MERCHANT_SECRET;
+  if (!secretKey) throw new Error('X_SFPY_MERCHANT_SECRET is not set');
+
+  const merchantApiKey = process.env.SFPY_MERCHANT_API_KEY;
+  if (!merchantApiKey) throw new Error('SFPY_MERCHANT_API_KEY is not set');
+
+  const env = (process.env.DROPS_ENV || 'sandbox').toLowerCase();
+  const host = API_HOST_BY_ENV[env] ?? API_HOST_BY_ENV.sandbox;
+
+  const secretClient = new Safepay(secretKey, { authType: 'secret', host });
+  const passportRes = await secretClient.client.passport.create();
+  const authToken: string = passportRes.data;
+
+  const jwtClient = new Safepay(authToken, { authType: 'jwt', host });
+  const customerRes = await jwtClient.customers.object.create({
+    first_name: 'E2E',
+    last_name: 'Test',
+    email: `e2e+${Date.now()}@getsafepay.com`,
+    phone_number: '+923331234567',
+    country: 'PK',
+    is_guest: false,
+  });
+  const user: string = customerRes.data.token;
+
+  return { authToken, user, env, _merchantApiKey: merchantApiKey, _host: host };
+}
+
+export async function createTracker(session: LiveSession): Promise<string> {
+  const jwtClient = new Safepay(session.authToken, { authType: 'jwt', host: session._host });
+  const trackerRes = await jwtClient.payments.session.setup({
+    merchant_api_key: session._merchantApiKey,
+    intent: 'CYBERSOURCE',
+    mode: 'payment',
+    currency: 'PKR',
+    user: session.user,
+    amount: 5000,
+    entry_mode: 'raw',
+  });
+  return trackerRes.data.tracker.token;
+}

--- a/tests/e2e/test-cards.ts
+++ b/tests/e2e/test-cards.ts
@@ -1,0 +1,241 @@
+export type TestCardOutcome = 'proceed' | 'reject';
+export type TestCardFlow = 'frictionless' | 'step-up';
+
+export interface TestCard {
+  scenario: string;
+  description: string;
+  number: string;
+  expiry: { mm: string; yy: string };
+  cvv: string;
+  flow: TestCardFlow;
+  outcome: TestCardOutcome;
+}
+
+const EXPIRY = { mm: '12', yy: '34' };
+const CVV = '123';
+
+export const TEST_CARDS: TestCard[] = [
+  // ─── Frictionless ────────────────────────────────────────────────────────────
+  {
+    scenario: '2.1',
+    description: 'Successful Frictionless Authentication (Visa)',
+    number: '4456530000001005',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.1',
+    description: 'Successful Frictionless Authentication (Mastercard)',
+    number: '5200000000001005',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.2',
+    description: 'Unsuccessful Frictionless Authentication (Visa)',
+    number: '4456530000001013',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'reject',
+  },
+  {
+    scenario: '2.2',
+    description: 'Unsuccessful Frictionless Authentication (Mastercard)',
+    number: '5200000000001013',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'reject',
+  },
+  {
+    scenario: '2.3',
+    description: 'Attempts Processing Frictionless Authentication (Visa)',
+    number: '4456530000001021',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.3',
+    description: 'Attempts Processing Frictionless Authentication (Mastercard)',
+    number: '5200000000001021',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.4',
+    description: 'Unavailable Frictionless Authentication (Visa)',
+    number: '4456530000001039',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.4',
+    description: 'Unavailable Frictionless Authentication (Mastercard)',
+    number: '5200000000001039',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.5',
+    description: 'Rejected Frictionless Authentication (Visa)',
+    number: '4456530000001047',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'reject',
+  },
+  {
+    scenario: '2.5',
+    description: 'Rejected Frictionless Authentication (Mastercard)',
+    number: '5200000000001047',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'reject',
+  },
+  {
+    scenario: '2.6',
+    description: 'Authentication Not Available on Lookup (Visa)',
+    number: '4456530000001054',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.6',
+    description: 'Authentication Not Available on Lookup (Mastercard)',
+    number: '5200000000001054',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.7',
+    description: 'Enrollment Check Error (Visa)',
+    number: '4456530000001062',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.7',
+    description: 'Enrollment Check Error (Mastercard)',
+    number: '5200000000001062',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.8',
+    description: 'Time-Out (Visa)',
+    number: '4456530000001070',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.8',
+    description: 'Time-Out (Mastercard)',
+    number: '5200000000001070',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.9',
+    description: 'Bypassed Authentication (Visa)',
+    number: '4456530000001088',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.9',
+    description: 'Bypassed Authentication (Mastercard)',
+    number: '5200000000001088',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'frictionless',
+    outcome: 'proceed',
+  },
+
+  // ─── Step-up (challenge) ──────────────────────────────────────────────────────
+  {
+    scenario: '2.10a',
+    description: 'Successful Step-Up Authentication (Visa)',
+    number: '4456530000001096',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'step-up',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.10a',
+    description: 'Successful Step-Up Authentication (Mastercard)',
+    number: '5200000000001096',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'step-up',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.11a',
+    description: 'Unsuccessful Step-Up Authentication (Visa)',
+    number: '4456530000001104',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'step-up',
+    outcome: 'reject',
+  },
+  {
+    scenario: '2.11a',
+    description: 'Unsuccessful Step-Up Authentication (Mastercard)',
+    number: '5200000000001104',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'step-up',
+    outcome: 'reject',
+  },
+  {
+    scenario: '2.12a',
+    description: 'Unavailable Step-Up Authentication (Visa)',
+    number: '4456530000001112',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'step-up',
+    outcome: 'proceed',
+  },
+  {
+    scenario: '2.12a',
+    description: 'Unavailable Step-Up Authentication (Mastercard)',
+    number: '5200000000001112',
+    expiry: EXPIRY,
+    cvv: CVV,
+    flow: 'step-up',
+    outcome: 'proceed',
+  },
+];
+
+export const REGRESSION_CARDS = TEST_CARDS.filter((c) =>
+  ['2.1', '2.2', '2.10a', '2.11a'].includes(c.scenario)
+);

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/live-session.ts` — generates fresh auth token, customer, and tracker per run from `X_SFPY_MERCHANT_SECRET` + `SFPY_MERCHANT_API_KEY` via `@sfpy/node-core`
- Adds `tests/e2e/test-cards.ts` — all 3DS 2.0 CyberSource test card data with `flow`/`outcome` metadata; `REGRESSION_CARDS` covers the four key branches (frictionless success/fail, step-up success/fail)
- Updates `tests/e2e/atoms.spec.ts` — replaces the two thin opt-in tests with a full regression loop; frictionless tests assert the correct callback (`unavailable` for `enrollment__failed`), step-up tests automate the Cardinal ACS challenge (OTP `1234`) and assert `success`/`failure`
- Adds `tests/tsconfig.json` to scope Node type definitions to test files only

## Running locally

```sh
USE_REAL_DROPS=1 DROPS_ENV=development \
X_SFPY_MERCHANT_SECRET=<secret> SFPY_MERCHANT_API_KEY=<public-key> \
pnpm test:e2e
```

## Test plan

- [ ] Mocked atoms tests still pass (`pnpm test:e2e --project=atoms`)
- [ ] `2.1` frictionless success (Visa + Mastercard) — `onPayerAuthenticationFrictionless` fires
- [ ] `2.2` frictionless failure (Visa + Mastercard) — `onPayerAuthenticationUnavailable` fires
- [ ] `2.10a` step-up success (Visa + Mastercard) — Cardinal ACS filled, `onPayerAuthenticationSuccess` fires
- [ ] `2.11a` step-up failure (Visa + Mastercard) — Cardinal ACS filled, `onPayerAuthenticationFailure` fires