### PR TITLE
fix: forward error details for payer auth enrollment failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "packageManager": "pnpm@10.11.1",
     "description": "Atomic building blocks to build custom payment interfaces",
     "type": "module",

--- a/src/atoms/PayerAuthenticationIframe/index.tsx
+++ b/src/atoms/PayerAuthenticationIframe/index.tsx
@@ -97,7 +97,7 @@ const PayerAuthentication = ({
         onPayerAuthenticationFrictionless(data);
         break;
       case 'safepay-inframe__enrollment__failed':
-        onPayerAuthenticationUnavailable({ tracker });
+        onPayerAuthenticationUnavailable({ tracker, ...data });
         break;
       case 'safepay-inframe__cardinal-3ds__failure':
         onPayerAuthenticationFailure(data);

--- a/src/atoms/PayerAuthenticationIframe/types.ts
+++ b/src/atoms/PayerAuthenticationIframe/types.ts
@@ -1,6 +1,7 @@
 interface PayerAuthData {
   tracker: string;
   request_id?: string;
+  errorMessage?: string;
 }
 
 interface PayerAuthErrorData extends PayerAuthData {


### PR DESCRIPTION
## Summary

- Spreads the full `safepay-inframe__enrollment__failed` event detail into `onPayerAuthenticationUnavailable`, so merchants receive `errorMessage` alongside `tracker`
- Adds `errorMessage?: string` to `PayerAuthData` type

Previously, `onPayerAuthenticationUnavailable` was hardcoded to `{ tracker }`, discarding the `errorMessage` that drops sends with the event. Merchants had to rely on `onSafepayError` as a second source of truth for the failure reason — which is one of the duplicate callbacks being fixed in the paired drops PR.

## Linked PRs

| Repo | PR |
|------|----|
| safepay-drops | getsafepay/safepay-drops#74 |
| android-drops-sdk | getsafepay/android-drops-sdk#1 |
| swift-drops-sdk | getsafepay/swift-drops-sdk#2 |
| sfpy-react-native | getsafepay/sfpy-react-native#11 |
| android-drops-sdk-example | getsafepay/android-drops-sdk-example#1 |
| swift-drops-sdk-example | getsafepay/swift-drops-sdk-example#1 |
| safepay-react-native-sdk-example | getsafepay/safepay-react-native-sdk-example#3 |