### PR TITLE
feat: include bin, lastFour and cardType in onValidated callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Set properties directly on the element for functions, objects, and non-string va
 | forcePromoCode                     | boolean   | When `true` and a `promoCode` is set, BIN-based card scheme discounts are ignored and the promo code is always used. |
 | onReady                             | function  | Callback when the embedded iframe signals it is ready |
 | onError                            | function  | Error callback handler                   |
-| onValidated                        | function  | Validation success callback             |
+| onValidated                        | `(data: { bin: string; lastFour: string; cardType?: string }) => void` | Called when the card passes client-side validation. Receives the first 6 digits (`bin`), last 4 digits (`lastFour`), and the detected card type (`cardType`, e.g. `"visa"`). |
 | onDiscountApplied                  | function  | Discount applied callback (includes `discountBody`) |
 | onProceedToAuthentication          | function  | Authentication proceed callback         |
 | imperativeRef                      | CardCaptureImperativeRef | Ref object for imperative methods (optional) |
@@ -80,7 +80,7 @@ Attributes are string-only. For callbacks and objects, set properties directly:
 <script type="module">
   const cardAtom = document.getElementById('card-atom');
   cardAtom.onReady = () => console.log('ready');
-  cardAtom.onValidated = () => console.log('validated');
+  cardAtom.onValidated = ({ bin, lastFour, cardType }) => console.log('validated', bin, lastFour, cardType);
   cardAtom.onProceedToAuthentication = (data) => console.log('auth', data);
 </script>
 ```
@@ -386,7 +386,7 @@ function PaymentForm() {
         imperativeRef={cardRef}
         // Optional callbacks:
         // onReady={() => console.log('Card iframe ready')}
-        // onValidated={() => console.log('Card validated')}
+        // onValidated={(data) => console.log('Card validated', data.bin, data.lastFour, data.cardType)}
         // onDiscountApplied={(data) => console.log('Discount applied', data)}
         // onProceedToAuthentication={(data) => console.log('Proceed to auth', data)}
         // onError={(error) => console.error('Error', error)}
@@ -410,7 +410,7 @@ function PaymentForm() {
 | forcePromoCode                | boolean                      | When `true` and a `promoCode` is set, BIN-based card scheme discounts are ignored and the promo code is always used. |          |
 | onReady                       | () => void                   | Callback when the embedded iframe signals it is ready   |          |
 | onProceedToAuthentication     | (data: any) => void           | Callback when ready to proceed to authentication        |          |
-| onValidated                   | () => void                   | Callback on successful validation                       |          |
+| onValidated                   | `(data: CardValidatedData) => void` | Called when the card passes client-side validation. Receives `{ bin, lastFour, cardType? }`. |          |
 | onDiscountApplied             | (data: any) => void           | Callback when a discount is applied (includes `discountBody`) |          |
 | onError                       | (error: string) => void       | Error handling callback                                |          |
 | imperativeRef                 | React.MutableRefObject<any>  | Ref to control the component imperatively               | ✅ |
@@ -650,7 +650,7 @@ export default function CombinedDemo() {
           // promoCode="SAVE10"  — optional: auto-applies this promo code once offers load
           onReady={() => console.log('card iframe ready')}
           onError={(error) => console.log(error)}
-          onValidated={() => console.log('validated')}
+          onValidated={(data) => console.log('validated', data.bin, data.lastFour, data.cardType)}
           onDiscountApplied={(data) => {
             if (data?.discountBody) {
               setDiscountBody(data.discountBody);

--- a/examples/card-links-demo.html
+++ b/examples/card-links-demo.html
@@ -57,7 +57,7 @@
   <script type="text/javascript">
 
     var ENVIRONMENT = 'sandbox';
-    var TRACKER = 'your_tracker_token';
+    var TRACKER = 'your_tracker_id';
     var CLIENT_SECRET = 'your_auth_token';
     var PROMO_CODE = '';       // optional: set to a promo code string to auto-apply it on load
     var FORCE_PROMO_CODE = false; // optional: when true, ignores BIN discounts and always applies the promo code
@@ -88,27 +88,22 @@
     payerAuthAtom.onPayerAuthenticationFailure = function (data) {
       console.log('onPayerAuthenticationFailure', data);
       modal.classList.remove('show');
-      modal.classList.add('hide');
     };
     payerAuthAtom.onPayerAuthenticationSuccess = function (data) {
       console.log('onPayerAuthenticationSuccess', data);
       modal.classList.remove('show');
-      modal.classList.add('hide');
     };
     payerAuthAtom.onPayerAuthenticationFrictionless = function (data) {
       console.log('onPayerAuthenticationFrictionless', data);
       modal.classList.remove('show');
-      modal.classList.add('hide');
     };
     payerAuthAtom.onPayerAuthenticationUnavailable = function (data) {
       console.log('onPayerAuthenticationUnavailable', data);
       modal.classList.remove('show');
-      modal.classList.add('hide');
     };
     payerAuthAtom.onSafepayError = function (error) {
       console.log('onSafepayError', error.message);
       modal.classList.remove('show');
-      modal.classList.add('hide');
     };
 
     cardAtom.environment = ENVIRONMENT;
@@ -128,8 +123,8 @@
     cardAtom.onError = function (err) {
       console.log(err);
     };
-    cardAtom.onValidated = function () {
-      console.log('validated');
+    cardAtom.onValidated = function (data) {
+      console.log('validated', data.bin, data.lastFour, data.cardType);
     };
     cardAtom.onDiscountApplied = function (data) {
       if (data && data.discountBody) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sfpy/atoms",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "packageManager": "pnpm@10.11.1",
     "description": "Atomic building blocks to build custom payment interfaces",
     "type": "module",

--- a/src/atoms/CardCaptureIframe/index.test.tsx
+++ b/src/atoms/CardCaptureIframe/index.test.tsx
@@ -62,11 +62,11 @@ describe('CardCapture', () => {
     expect(onError).toHaveBeenCalledWith('bad card');
   });
 
-  it('calls onValidated when the validated event fires', () => {
+  it('calls onValidated with card data when the validated event fires', () => {
     const onValidated = vi.fn();
     render(<CardCapture {...defaultProps} onValidated={onValidated} />);
-    act(() => { capturedOnInframeEvent?.('safepay-inframe__validated', {}); });
-    expect(onValidated).toHaveBeenCalledOnce();
+    act(() => { capturedOnInframeEvent?.('safepay-inframe__validated', { bin: '411111', lastFour: '1111', cardType: 'visa' }); });
+    expect(onValidated).toHaveBeenCalledWith({ bin: '411111', lastFour: '1111', cardType: 'visa' });
   });
 
   it('populates imperativeRef with submit, validate, fetchValidity and clear', () => {

--- a/src/atoms/CardCaptureIframe/index.tsx
+++ b/src/atoms/CardCaptureIframe/index.tsx
@@ -5,6 +5,12 @@ import { resolveBaseUrl } from '../../utils/funcs/resolveBaseUrl';
 import InframeComponent from './iframe';
 import { Environment, toEnvironment } from '../../types/environment';
 
+export type CardValidatedData = {
+  bin: string;
+  lastFour: string;
+  cardType?: string;
+};
+
 export interface CardCaptureProps {
   environment: Environment | string;
   authToken: string;
@@ -15,7 +21,7 @@ export interface CardCaptureProps {
   forcePromoCode?: boolean;
   onDiscountApplied?: (payload: any) => void;
   onProceedToAuthentication?: (data: any) => void;
-  onValidated?: () => void;
+  onValidated?: (data: CardValidatedData) => void;
   onError?: (error: string) => void;
   onReady?: () => void;
   imperativeRef: React.MutableRefObject<any>; // Replace 'any' with a specific type if possible
@@ -62,7 +68,7 @@ const CardCapture = ({
     inputStyle,
     promoCode,
     forcePromoCode,
-    onValidated = () => {},
+    onValidated = (_data: CardValidatedData) => {},
     onDiscountApplied = () => {},
     onProceedToAuthentication = () => {},
     onError = (e: string) => {},
@@ -154,7 +160,7 @@ const CardCapture = ({
       //   break;
       case 'safepay-inframe__validated':
         setErrorMessage(undefined);
-        onValidated();
+        onValidated(data as CardValidatedData);
         break;
       case 'safepay-inframe__fetch-validity':
         if (validationCallbackRef.current) {


### PR DESCRIPTION
## Summary

- Adds `CardValidatedData` type: `{ bin: string; lastFour: string; cardType?: string }`
- Updates `onValidated` signature from `() => void` to `(data: CardValidatedData) => void`
- Updates unit test to assert the data is passed through correctly

## Usage

```tsx
<CardCapture
  ...
  onValidated={({ bin, lastFour, cardType }) => {
    console.log(bin, lastFour, cardType); // "411111", "1111", "visa"
  }}
/>
```

## Linked PR

- **safepay-drops** — getsafepay/safepay-drops#76 (sends the card details in the `safepay-inframe__validated` postMessage, includes E2E tests)